### PR TITLE
Downgrade twisted on Python 3.4 distros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Downgrade to twisted 19.2 on Python 3.4 distros ([#14](../../pull/14))
 
 ## [2.3.1-8] - 2019-06-06
 ### Changed

--- a/common/buildbot.m4
+++ b/common/buildbot.m4
@@ -8,7 +8,10 @@ RUN pip3 install --upgrade pip && \
         PLATFORM ARCH, debian i386,
         --only-binary cryptography ,
         PLATFORM ARCH, ubuntu i386,
-        --only-binary cryptography )twisted[tls] && \
+        --only-binary cryptography )m4_ifelse(
+        PLATFORM RELEASE, opensuse 42,
+        twisted[tls]==19.2,
+        twisted[tls]) && \
     pip --no-cache-dir install buildbot_worker==$BUILDBOT_VERSION
 
 RUN m4_ifelse(

--- a/common/buildbot.m4
+++ b/common/buildbot.m4
@@ -11,6 +11,8 @@ RUN pip3 install --upgrade pip && \
         --only-binary cryptography )m4_ifelse(
         PLATFORM RELEASE, opensuse 42,
         twisted[tls]==19.2,
+        PLATFORM RELEASE, debian 8,
+        twisted[tls]==19.2,
         twisted[tls]) && \
     pip --no-cache-dir install buildbot_worker==$BUILDBOT_VERSION
 

--- a/debian/8/i386/Dockerfile
+++ b/debian/8/i386/Dockerfile
@@ -13,7 +13,7 @@ RUN set -ex; \
 
 ENV BUILDBOT_VERSION 2.3.1
 RUN pip3 install --upgrade pip && \
-    pip --no-cache-dir install --only-binary cryptography twisted[tls] && \
+    pip --no-cache-dir install --only-binary cryptography twisted[tls]==19.2 && \
     pip --no-cache-dir install buildbot_worker==$BUILDBOT_VERSION
 
 RUN useradd --create-home --home-dir=/var/lib/buildbot buildbot

--- a/debian/8/x86_64/Dockerfile
+++ b/debian/8/x86_64/Dockerfile
@@ -13,7 +13,7 @@ RUN set -ex; \
 
 ENV BUILDBOT_VERSION 2.3.1
 RUN pip3 install --upgrade pip && \
-    pip --no-cache-dir install twisted[tls] && \
+    pip --no-cache-dir install twisted[tls]==19.2 && \
     pip --no-cache-dir install buildbot_worker==$BUILDBOT_VERSION
 
 RUN useradd --create-home --home-dir=/var/lib/buildbot buildbot

--- a/opensuse/42/x86_64/Dockerfile
+++ b/opensuse/42/x86_64/Dockerfile
@@ -11,7 +11,7 @@ RUN set -ex; \
 
 ENV BUILDBOT_VERSION 2.3.1
 RUN pip3 install --upgrade pip && \
-    pip --no-cache-dir install twisted[tls] && \
+    pip --no-cache-dir install twisted[tls]==19.2 && \
     pip --no-cache-dir install buildbot_worker==$BUILDBOT_VERSION
 
 RUN useradd --create-home --home-dir=/var/lib/buildbot buildbot


### PR DESCRIPTION
Twisted 19.7 dropped Python 3.4 support:

  https://github.com/twisted/twisted/blob/twisted-19.7.0/NEWS.rst#twisted-1970-2019-07-28

- OpenSUSE 42 comes with Python 3.4.6.
- Debian 8 comes with Python 3.4.2.
